### PR TITLE
refactor: replace os.system() with subprocess.run()

### DIFF
--- a/crappy/_git.py
+++ b/crappy/_git.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-import os
+import subprocess
 import logging
 
 logger = logging.getLogger(__name__)
@@ -11,4 +11,10 @@ def initialize_git(project_path: Path) -> None:
     :param project_path: The path to the project directory.
     """
     logger.info(f"Initializing git repository in {project_path}")
-    os.system(f"git init {project_path}")
+    result = subprocess.run(
+        ["git", "init", str(project_path)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to initialize git: {result.stderr}")

--- a/crappy/_git.py
+++ b/crappy/_git.py
@@ -11,10 +11,15 @@ def initialize_git(project_path: Path) -> None:
     :param project_path: The path to the project directory.
     """
     logger.info(f"Initializing git repository in {project_path}")
+    command = ["git", "init", str(project_path)]
     result = subprocess.run(
-        ["git", "init", str(project_path)],
+        command,
         capture_output=True,
         text=True,
     )
     if result.returncode != 0:
-        raise RuntimeError(f"Failed to initialize git: {result.stderr}")
+        diagnostics = result.stderr.strip() or result.stdout.strip() or "No output captured."
+        raise RuntimeError(
+            f"Failed to initialize git with command {' '.join(command)!r} "
+            f"(exit code {result.returncode}): {diagnostics}"
+        )

--- a/crappy/_virtenv.py
+++ b/crappy/_virtenv.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-import os
+import subprocess
 import logging
 
 logger = logging.getLogger(__name__)
@@ -13,5 +13,11 @@ def create_virtualenv(project_path: Path) -> Path:
     """
     venv_path = project_path / ".venv"
     logger.info(f"Creating virtual environment in {venv_path}")
-    os.system(f"uv venv {venv_path}")
+    result = subprocess.run(
+        ["uv", "venv", str(venv_path)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to create virtual environment: {result.stderr}")
     return venv_path / "bin" / "python"

--- a/crappy/_virtenv.py
+++ b/crappy/_virtenv.py
@@ -13,11 +13,21 @@ def create_virtualenv(project_path: Path) -> Path:
     """
     venv_path = project_path / ".venv"
     logger.info(f"Creating virtual environment in {venv_path}")
+    cmd = ["uv", "venv", str(venv_path)]
     result = subprocess.run(
-        ["uv", "venv", str(venv_path)],
+        cmd,
         capture_output=True,
         text=True,
     )
     if result.returncode != 0:
-        raise RuntimeError(f"Failed to create virtual environment: {result.stderr}")
+        stderr = (result.stderr or "").strip()
+        stdout = (result.stdout or "").strip()
+        details = stderr or stdout
+        if stderr and stdout:
+            details = f"{stderr}\n{stdout}"
+        raise RuntimeError(
+            f"Failed to create virtual environment with command {cmd!r} "
+            f"(return code {result.returncode})"
+            f"{': ' + details if details else ''}"
+        )
     return venv_path / "bin" / "python"


### PR DESCRIPTION
## Summary
- Replace `os.system()` with `subprocess.run()` in `_git.py` and `_virtenv.py`
- Capture stderr so failures surface actionable error messages
- Raise `RuntimeError` on non-zero exit so callers know what broke

## Test plan
- [ ] Run `make test` to verify existing tests pass
- [ ] Manually trigger a failure (e.g. bad path) to confirm error message includes stderr